### PR TITLE
feat: install aws-cli

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,8 +1,7 @@
 version: 2.1
 orbs:
   aws-health: circleci/aws-health@dev:<<pipeline.git.revision>>
-  orb-tools: circleci/orb-tools@11.1
-  aws-cli: circleci/aws-cli@3.1
+  orb-tools: circleci/orb-tools@11.3
 
 filters: &filters
   tags:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -11,7 +11,7 @@ filters: &filters
 jobs:
   command-tests:
     docker:
-      - image: cimg/aws:2022.09
+      - image: cimg/base:current
     steps:
       - aws-health/check-health
 workflows:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -10,3 +10,6 @@ description: >
 display:
   home_url: "https://docs.aws.amazon.com/health/latest/ug/health-api.html"
   source_url: "https://github.com/CircleCI-Public/aws-health-orb"
+
+orbs:
+  aws-cli: circleci/aws-cli@3.1

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -4,7 +4,7 @@ description: >
   This orb enables users to check the health of a specific AWS region for any issues. If there are issues
   detected, the aws-health/health-check command waits for the issue to be resolved before continuing on to
   next steps in the job. If the issue is not resolved before the maximum check attempts have been reached,
-  the job will fail. This is especially useful during deployments. The AWS Healh Orb can help prevent
+  the job will fail. This is especially useful during deployments. The AWS Health Orb can help prevent
   deployments to an AWS region with known issues.
 
 display:

--- a/src/commands/check-health.yml
+++ b/src/commands/check-health.yml
@@ -15,7 +15,35 @@ parameters:
     description: >
       The max number of attempts to recheck for issues in the specified AWS region. Each attempt takes
       10 seconds. By default, 6 attempts will be made for a total of 1 minute.
+  aws-access-key-id:
+    type: env_var_name
+    description: aws access key id override
+    default: AWS_ACCESS_KEY_ID
+  aws-secret-access-key:
+    type: env_var_name
+    description: aws secret access key override
+    default: AWS_SECRET_ACCESS_KEY
+  aws-region:
+    type: env_var_name
+    description: aws region override
+    default: AWS_REGION
+  profile-name:
+    description: AWS profile name to be configured.
+    type: string
+    default: ''
+  install-aws-cli:
+    description: The aws-cli is installed when this parameter is set to true. Set to false to skip installation
+    type: boolean
+    default: true
 steps:
+  - when:
+      condition: <<parameters.install-aws-cli>>
+      steps:
+        - aws-cli/setup:
+            aws-access-key-id: << parameters.aws-access-key-id >>
+            aws-secret-access-key: << parameters.aws-secret-access-key >>
+            aws-region: << parameters.aws-region >>
+            profile-name: << parameters.profile-name >>
   - run:
       name: Checking Health of AWS region.
       environment:


### PR DESCRIPTION
This `PR` adds the `install-aws-cli` parameter to the `check-health` command in the `AWS Health` Orb. The `aws-cli` will be installed unless the `install-aws-cli` parameter is set top `false`. This branch merges into the `alpha` branch. Once the orb is complete and ready for a new release, the `alpha` branch will be merged into `main`.