### PR TITLE
feat: add health-check job

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,24 +1,33 @@
 version: 2.1
 orbs:
   aws-health: circleci/aws-health@dev:<<pipeline.git.revision>>
-  orb-tools: circleci/orb-tools@11.1
-  aws-cli: circleci/aws-cli@3.1
+  orb-tools: circleci/orb-tools@11.3
 
 filters: &filters
   tags:
     only: /.*/
-
-jobs:
-  command-tests:
+executors:
+  alpine:
+    docker: 
+      - image: alpine:latest
+  docker-base:
     docker:
-      - image: cimg/base:current
-    steps:
-      - aws-health/check-health
+      - image: cimg/base:stable
+  windows:
+    machine:
+      image: windows-server-2019-vs2019:stable
+    shell: bash.exe
+    resource_class: windows.medium
+  macos:
+    macos:
+      xcode: 13.3
 workflows:
   test-deploy:
     jobs:
-      - command-tests:
+      - aws-health/check-health:
+          name: integration-test
           context: CPE_ORBS_AWS
+          executor: alpine
           filters: *filters
       - orb-tools/pack:
           filters: *filters
@@ -28,7 +37,7 @@ workflows:
           pub-type: production
           requires:
             - orb-tools/pack
-            - command-tests
+            - integration-test
           context: orb-publisher
           filters:
             branches:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -15,7 +15,7 @@ executors:
       - image: cimg/base:stable
   windows:
     machine:
-      image: windows-server-2019-vs2019:stable
+      image: windows-server-2022-gui:current
     shell: bash.exe
     resource_class: windows.medium
   macos:
@@ -25,9 +25,11 @@ workflows:
   test-deploy:
     jobs:
       - aws-health/check-health:
-          name: integration-test
+          name: integration-test-<<matrix.executor>>
           context: CPE_ORBS_AWS
-          executor: alpine
+          matrix:
+            parameters:
+              executor: [ "alpine", "docker-base", "windows", "macos" ]
           filters: *filters
       - orb-tools/pack:
           filters: *filters
@@ -37,7 +39,10 @@ workflows:
           pub-type: production
           requires:
             - orb-tools/pack
-            - integration-test
+            - integration-test-alpine
+            - integration-test-docker-base
+            - integration-test-windows
+            - integration-test-macos
           context: orb-publisher
           filters:
             branches:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -12,7 +12,7 @@ executors:
       - image: alpine:latest
   docker-base:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/base:current
   windows:
     machine:
       image: windows-server-2022-gui:current

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -11,7 +11,7 @@ filters: &filters
 jobs:
   command-tests:
     docker:
-      - image: cimg/aws:2022.09
+      - image: cimg/base:current
     steps:
       - aws-health/check-health
 workflows:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -10,3 +10,6 @@ description: >
 display:
   home_url: "https://docs.aws.amazon.com/health/latest/ug/health-api.html"
   source_url: "https://github.com/CircleCI-Public/aws-health-orb"
+
+orbs:
+  aws-cli: circleci/aws-cli@3.1

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -4,7 +4,7 @@ description: >
   This orb enables users to check the health of a specific AWS region for any issues. If there are issues
   detected, the aws-health/health-check command waits for the issue to be resolved before continuing on to
   next steps in the job. If the issue is not resolved before the maximum check attempts have been reached,
-  the job will fail. This is especially useful during deployments. The AWS Healh Orb can help prevent
+  the job will fail. This is especially useful during deployments. The AWS Health Orb can help prevent
   deployments to an AWS region with known issues.
 
 display:

--- a/src/commands/check-health.yml
+++ b/src/commands/check-health.yml
@@ -15,7 +15,35 @@ parameters:
     description: >
       The max number of attempts to recheck for issues in the specified AWS region. Each attempt takes
       10 seconds. By default, 6 attempts will be made for a total of 1 minute.
+  aws-access-key-id:
+    type: env_var_name
+    description: aws access key id override
+    default: AWS_ACCESS_KEY_ID
+  aws-secret-access-key:
+    type: env_var_name
+    description: aws secret access key override
+    default: AWS_SECRET_ACCESS_KEY
+  aws-region:
+    type: env_var_name
+    description: aws region override
+    default: AWS_REGION
+  profile-name:
+    description: AWS profile name to be configured.
+    type: string
+    default: ''
+  install-aws-cli:
+    description: The aws-cli is installed when this parameter is set to true. Set to false to skip installation
+    type: boolean
+    default: true
 steps:
+  - when:
+      condition: <<parameters.install-aws-cli>>
+      steps:
+        - aws-cli/setup:
+            aws-access-key-id: << parameters.aws-access-key-id >>
+            aws-secret-access-key: << parameters.aws-secret-access-key >>
+            aws-region: << parameters.aws-region >>
+            profile-name: << parameters.profile-name >>
   - run:
       name: Checking Health of AWS region.
       environment:

--- a/src/commands/check-health.yml
+++ b/src/commands/check-health.yml
@@ -39,7 +39,7 @@ parameters:
     default: true
 steps:
   - when:
-      condition: <<parameters.install-aws-cli>>
+      condition: << parameters.install-aws-cli >>
       steps:
         - aws-cli/setup:
             aws-access-key-id: << parameters.aws-access-key-id >>
@@ -49,6 +49,6 @@ steps:
   - run:
       name: Checking Health of AWS region.
       environment:
-        PARAM_AWS_HEALTH_REGION_TO_CHECK: <<parameters.aws-region-to-check>>
-        PARAM_AWS_HEALTH_MAX_POLL_ATTEMPTS: <<parameters.max-poll-attempts>>
-      command: <<include(scripts/check-health.sh)>>
+        PARAM_AWS_HEALTH_REGION_TO_CHECK: << parameters.aws-region-to-check >>
+        PARAM_AWS_HEALTH_MAX_POLL_ATTEMPTS: << parameters.max-poll-attempts >>
+      command: << include(scripts/check-health.sh) >>

--- a/src/jobs/check-health.yml
+++ b/src/jobs/check-health.yml
@@ -46,6 +46,6 @@ steps:
       aws-secret-access-key: << parameters.aws-secret-access-key >>
       aws-region: << parameters.aws-region >>
       profile-name: << parameters.profile-name >>
-      aws-region-to-check: <<parameters.aws-region-to-check>>
+      aws-region-to-check: << parameters.aws-region-to-check >>
       max-poll-attempts: <<parameters.max-poll-attempts>>
       install-aws-cli: <<parameters.install-aws-cli>>

--- a/src/jobs/check-health.yml
+++ b/src/jobs/check-health.yml
@@ -1,11 +1,13 @@
 description: >
-  This command checks the specified AWS region for any issues. The command passes if there are no issues found.
-  If there are issues in the region, the command will continue to check for issues every 10 seconds until
-  no issues are detected. If the max attempts have been reached, the command will fail.
+  This job checks the specified AWS region for any issues. The job passes if there are no issues found.
+  If there are issues in the region, the job will continue to check for issues every 10 seconds until
+  no issues are detected. If the max attempts have been reached, the job will fail.
 
-  NOTE: This command requires jq. It will check for jq and install it if necessary.
+executor: <<parameters.executor>>
 
 parameters:
+  executor:
+    type: executor
   aws-region-to-check:
     type: env_var_name
     default: AWS_REGION
@@ -37,18 +39,10 @@ parameters:
     description: The aws-cli is installed when this parameter is set to true. Set to false to skip installation
     type: boolean
     default: true
+
 steps:
-  - when:
-      condition: <<parameters.install-aws-cli>>
-      steps:
-        - aws-cli/setup:
-            aws-access-key-id: << parameters.aws-access-key-id >>
-            aws-secret-access-key: << parameters.aws-secret-access-key >>
-            aws-region: << parameters.aws-region >>
-            profile-name: << parameters.profile-name >>
-  - run:
-      name: Checking Health of AWS region.
-      environment:
-        PARAM_AWS_HEALTH_REGION_TO_CHECK: <<parameters.aws-region-to-check>>
-        PARAM_AWS_HEALTH_MAX_POLL_ATTEMPTS: <<parameters.max-poll-attempts>>
-      command: <<include(scripts/check-health.sh)>>
+  - check-health:
+      aws-access-key-id: << parameters.aws-access-key-id >>
+      aws-secret-access-key: << parameters.aws-secret-access-key >>
+      aws-region: << parameters.aws-region >>
+      profile-name: << parameters.profile-name >>

--- a/src/jobs/check-health.yml
+++ b/src/jobs/check-health.yml
@@ -46,3 +46,6 @@ steps:
       aws-secret-access-key: << parameters.aws-secret-access-key >>
       aws-region: << parameters.aws-region >>
       profile-name: << parameters.profile-name >>
+      aws-region-to-check: <<parameters.aws-region-to-check>>
+      max-poll-attempts: <<parameters.max-poll-attempts>>
+      install-aws-cli: <<parameters.install-aws-cli>>

--- a/src/jobs/check-health.yml
+++ b/src/jobs/check-health.yml
@@ -48,4 +48,4 @@ steps:
       profile-name: << parameters.profile-name >>
       aws-region-to-check: << parameters.aws-region-to-check >>
       max-poll-attempts: <<parameters.max-poll-attempts>>
-      install-aws-cli: <<parameters.install-aws-cli>>
+      install-aws-cli: << parameters.install-aws-cli >>

--- a/src/jobs/check-health.yml
+++ b/src/jobs/check-health.yml
@@ -47,5 +47,5 @@ steps:
       aws-region: << parameters.aws-region >>
       profile-name: << parameters.profile-name >>
       aws-region-to-check: << parameters.aws-region-to-check >>
-      max-poll-attempts: <<parameters.max-poll-attempts>>
+      max-poll-attempts: << parameters.max-poll-attempts >>
       install-aws-cli: << parameters.install-aws-cli >>

--- a/src/scripts/check-health.sh
+++ b/src/scripts/check-health.sh
@@ -26,7 +26,7 @@ do
     if [ "${AWS_EVENTS}" = "[]" ]; then
         echo "No issues found in ${PARAM_AWS_HEALTH_REGION_TO_CHECK} region";
         exit 0;
-    elif [ i = "$PARAM_AWS_HEALTH_MAX_POLL_ATTEMPTS" ]; then
+    elif [ $i = "$PARAM_AWS_HEALTH_MAX_POLL_ATTEMPTS" ]; then
         echo "Max attempts reached. Issues found in ${PARAM_AWS_HEALTH_REGION_TO_CHECK} region:"
         echo "${AWS_EVENTS}"
         exit 1;

--- a/src/scripts/check-health.sh
+++ b/src/scripts/check-health.sh
@@ -26,7 +26,7 @@ do
     if [ "${AWS_EVENTS}" = "[]" ]; then
         echo "No issues found in ${PARAM_AWS_HEALTH_REGION_TO_CHECK} region";
         exit 0;
-    elif [ $i = "$PARAM_AWS_HEALTH_MAX_POLL_ATTEMPTS" ]; then
+    elif [ $i -eq "$PARAM_AWS_HEALTH_MAX_POLL_ATTEMPTS" ]; then
         echo "Max attempts reached. Issues found in ${PARAM_AWS_HEALTH_REGION_TO_CHECK} region:"
         echo "${AWS_EVENTS}"
         exit 1;
@@ -34,5 +34,4 @@ do
         sleep 10;
         i=$((i+1))
     fi
-
 done


### PR DESCRIPTION
This `PR` adds the `check-health` job to the `AWS Health` Orb. This branch merges into the `alpha` branch. Once the orb is complete and ready for a new release, the `alpha` branch will be merged into `main`.