### PR TITLE
feat!/auth-step-parameter 

### DIFF
--- a/.circleci/CODEOWNERS
+++ b/.circleci/CODEOWNERS
@@ -1,0 +1,4 @@
+# Ping these folks when changes are made to this repository
+* @CircleCI-Public/cpeng
+
+# We can also add orb-specifc codeowners at some point if desirable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 setup: true
 orbs:
-  orb-tools: circleci/orb-tools@11.1
+  orb-tools: circleci/orb-tools@11.6
   shellcheck: circleci/shellcheck@3.1
 
 filters: &filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -12,9 +12,12 @@ workflows:
     jobs:
       - aws-health/check-health:
           name: integration-test
-          context: CPE-OIDC
-          role-arn: arn:aws:iam::122211685980:role/CPE_HEALTH_OIDC_TEST
+          auth:
+            - aws-cli/setup:
+                role-arn: arn:aws:iam::122211685980:role/CPE_HEALTH_OIDC_TEST
+                profile-name: "OIDC-User"
           profile-name: "OIDC-User"
+          context: CPE-OIDC
           aws-region-to-check: "us-west-2"
           filters: *filters
       - orb-tools/pack:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -11,7 +11,7 @@ workflows:
   test-deploy:
     jobs:
       - aws-health/check-health:
-          name: integration-test-<<matrix.executor>>
+          name: integration-test
           context: CPE-OIDC
           role-arn: arn:aws:iam::122211685980:role/CPE_HEALTH_OIDC_TEST
           profile-name: "OIDC-User"

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   aws-health: circleci/aws-health@dev:<<pipeline.git.revision>>
-  orb-tools: circleci/orb-tools@11.3
+  orb-tools: circleci/orb-tools@11.6
   aws-cli: circleci/aws-cli@3.1
 
 filters: &filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -7,21 +7,6 @@ orbs:
 filters: &filters
   tags:
     only: /.*/
-executors:
-  alpine:
-    docker: 
-      - image: alpine:latest
-  docker-base:
-    docker:
-      - image: cimg/base:current
-  windows:
-    machine:
-      image: windows-server-2022-gui:current
-    shell: bash.exe
-    resource_class: windows.medium
-  macos:
-    macos:
-      xcode: 13.3
 workflows:
   test-deploy:
     jobs:
@@ -31,10 +16,6 @@ workflows:
           role-arn: arn:aws:iam::122211685980:role/CPE_HEALTH_OIDC_TEST
           profile-name: "OIDC-User"
           aws-region-to-check: "us-west-2"
-          matrix:
-            alias: integration-test
-            parameters:
-              executor: [ "alpine", "docker-base", "windows", "macos" ]
           filters: *filters
       - orb-tools/pack:
           filters: *filters

--- a/.github/ISSUE_TEMPLATE/CODEOWNERS
+++ b/.github/ISSUE_TEMPLATE/CODEOWNERS
@@ -1,4 +1,4 @@
 # Ping these folks when changes are made to this repository
-* @CircleCI-Public/cpeng
+* @CircleCI-Public/orb-publishers
 
 # We can also add orb-specifc codeowners at some point if desirable

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -11,5 +11,3 @@ display:
   home_url: "https://docs.aws.amazon.com/health/latest/ug/health-api.html"
   source_url: "https://github.com/CircleCI-Public/aws-health-orb"
 
-orbs:
-  aws-cli: circleci/aws-cli@3.1

--- a/src/commands/check-health.yml
+++ b/src/commands/check-health.yml
@@ -18,61 +18,11 @@ parameters:
     description: >
       The max number of attempts to recheck for issues in the specified AWS region. Each attempt takes
       10 seconds. By default, 6 attempts will be made for a total of 1 minute.
-  aws-access-key-id:
-    type: env_var_name
-    description: aws access key id override
-    default: AWS_ACCESS_KEY_ID
-  aws-secret-access-key:
-    type: env_var_name
-    description: aws secret access key override
-    default: AWS_SECRET_ACCESS_KEY
-  aws-region:
-    type: env_var_name
-    description: aws region override
-    default: AWS_REGION
   profile-name:
     description: AWS profile name to be configured.
     type: string
     default: ''
-  role-arn:
-    description: |
-      The Amazon Resource Name (ARN) of the role that the caller is assuming.
-      Role ARN must be configured for web identity.
-    type: string
-    default: ""
-  role-session-name:
-    description: An identifier for the assumed role session. Environment variables will be evaluated.
-    type: string
-    default: ${CIRCLE_JOB}
-  session-duration:
-    description: The duration of the session in seconds
-    type: string
-    default: "3600"
-  install-aws-cli:
-    description: The aws-cli is installed when this parameter is set to true. Set to false to skip installation
-    type: boolean
-    default: true
 steps:
-  - when:
-      condition: << parameters.install-aws-cli >>
-      steps:
-        - when:
-            condition: << parameters.role-arn >>
-            steps:
-              - aws-cli/setup:
-                  role-arn: << parameters.role-arn >>
-                  profile-name: << parameters.profile-name >>
-                  session-duration: << parameters.session-duration >>
-                  aws-region: << parameters.aws-region >>
-                  role-session-name: << parameters.role-session-name >>
-        - unless:
-            condition: << parameters.role-arn >>
-            steps:
-              - aws-cli/setup:
-                  aws-access-key-id: << parameters.aws-access-key-id >>
-                  aws-secret-access-key: << parameters.aws-secret-access-key >>
-                  aws-region: << parameters.aws-region >>
-                  profile-name: << parameters.profile-name >>
   - run:
       name: Checking Health of AWS << parameters.aws-region-to-check >>
       environment:

--- a/src/commands/check-health.yml
+++ b/src/commands/check-health.yml
@@ -21,11 +21,12 @@ parameters:
   profile-name:
     description: AWS profile name to be configured.
     type: string
-    default: ''
+    default: "default"
 steps:
   - run:
       name: Checking Health of AWS << parameters.aws-region-to-check >>
       environment:
         PARAM_AWS_HEALTH_REGION_TO_CHECK: << parameters.aws-region-to-check >>
         PARAM_AWS_HEALTH_MAX_POLL_ATTEMPTS: << parameters.max-poll-attempts >>
+        PARAM_AWS_HEALTH_MAX_POLL_PROFILE: << parameters.profile-name >>
       command: << include(scripts/check-health.sh) >>

--- a/src/examples/check-health-command.yml
+++ b/src/examples/check-health-command.yml
@@ -15,11 +15,13 @@ usage:
         - image: cimg/base:current
       steps:
         # Check health of us-west-1 region before updating ecs service
+        - aws-cli/setup:
+            profile: "OIDC-USER"
+            role-arn: "arn:aws:iam::123456789012:role/VALID_OIDC_CODEDEPLOY_ROLE"
         - aws-health/check-health:
+            profile: "OIDC-USER"
             aws-region-to-check: "us-west-1"
             max-poll-attempts: 10
-            # Provide a valid role-arn to use OIDC
-            role-arn: "arn:aws:iam::123456789012:role/OIDC_ARN"
         # This command only runs if the above command does not detect issues
         - aws-ecs/update-service:
             family: '${MY_APP_PREFIX}-service'

--- a/src/examples/check-health-job-with-oidc.yml
+++ b/src/examples/check-health-job-with-oidc.yml
@@ -1,0 +1,24 @@
+description: >
+  Check for outages in a specific AWS region with the aws-health/check-health using OIDC authentication.
+usage:
+  version: 2.1
+  orbs:
+    aws-health: circleci/aws-health@1.0
+    # Importing aws-cli orb is required for OIDC authentication
+    aws-cli: circleci/aws-cli@3.1
+
+  workflows:
+    check-health-and-deploy:
+      jobs:
+        - aws-health/check-health:
+            auth:
+              # Add authentication step with OIDC using aws-cli/setup command
+              - aws-cli/setup:
+                  profile: "OIDC-USER"
+                  role-arn: "arn:aws:iam::123456789012:role/VALID_OIDC_CODEDEPLOY_ROLE"
+            aws-region-to-check: "us-west-1"
+            context: [CircleCI-OIDC-Token]
+
+
+
+

--- a/src/examples/check-health-job-with-static-keys.yml
+++ b/src/examples/check-health-job-with-static-keys.yml
@@ -1,0 +1,26 @@
+description: >
+  Check for outages in a specific AWS region with the aws-health/check-health using static AWS keys for authentication.
+  Import the aws-cli orb and authenticate using the aws-cli/setup command with
+  static AWS keys stored as env_vars (AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY).
+usage:
+  version: 2.1
+  orbs:
+    aws-health: circleci/aws-health@1.0
+    # Importing aws-cli orb is required for authentication
+    aws-cli: circleci/aws-cli@3.1
+
+  workflows:
+    check-health-and-deploy:
+      jobs:
+        - aws-health/check-health:
+            auth:
+              # Configure aws credentials with static keys stored as env_vars (AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY)
+              - aws-cli/setup:
+                  profile: "OIDC-USER"
+                  role-arn: "arn:aws:iam::123456789012:role/VALID_OIDC_CODEDEPLOY_ROLE"
+            aws-region-to-check: "us-west-1"
+            context: [CircleCI-OIDC-Token]
+
+
+
+

--- a/src/examples/check-health-job.yml
+++ b/src/examples/check-health-job.yml
@@ -12,7 +12,7 @@ usage:
   workflows:
     check-health-and-deploy:
       jobs:
-        - aws-cli/setup      
+        - aws-cli/setup
         - aws-health/check-health:
             aws-region-to-check: "us-west-1"
             max-poll-attempts: 10

--- a/src/examples/check-health-job.yml
+++ b/src/examples/check-health-job.yml
@@ -12,12 +12,10 @@ usage:
   workflows:
     check-health-and-deploy:
       jobs:
+        - aws-cli/setup      
         - aws-health/check-health:
             aws-region-to-check: "us-west-1"
             max-poll-attempts: 10
-            # Provide a valid role-arn to use OIDC
-            role-arn: "arn:aws:iam::123456789012:role/OIDC_ARN"
-            context: [CircleCI-OIDC-Token]
         - aws-ecs/deploy-service-update:
             # By requiring the job above, this job only runs if aws-health/check-health job passes
             requires:

--- a/src/jobs/check-health.yml
+++ b/src/jobs/check-health.yml
@@ -3,11 +3,7 @@ description: >
   If there are issues in the region, the job will continue to check for issues every 10 seconds until
   no issues are detected. If the max attempts have been reached, the job will fail.
 
-executor: <<parameters.executor>>
-
 parameters:
-  executor:
-    type: executor
   aws-region-to-check:
     type: string
     default: ${AWS_REGION}
@@ -54,7 +50,8 @@ parameters:
     description: The aws-cli is installed when this parameter is set to true. Set to false to skip installation
     type: boolean
     default: true
-
+docker:
+  - image: cimg/aws:2023.03
 steps:
   - check-health:
       aws-access-key-id: << parameters.aws-access-key-id >>

--- a/src/jobs/check-health.yml
+++ b/src/jobs/check-health.yml
@@ -20,6 +20,11 @@ parameters:
     description: AWS profile name to be configured.
     type: string
     default: "default"
+  auth:
+    description: |
+      The authentication method used to access your AWS account. Import the aws-cli orb in your config and
+      provide the aws-cli/setup command to authenticate with your preferred method. View examples for more information.
+    type: steps
   image-tag:
     description: >
       The tag for the cimg/aws image. It defaults to 2023.03. For more information, please visit the image registry at
@@ -29,6 +34,7 @@ parameters:
 docker:
   - image: cimg/aws:<< parameters.image-tag >>
 steps:
+  - steps: << parameters.auth >>
   - check-health:
       profile-name: << parameters.profile-name >>
       aws-region-to-check: << parameters.aws-region-to-check >>

--- a/src/jobs/check-health.yml
+++ b/src/jobs/check-health.yml
@@ -50,8 +50,14 @@ parameters:
     description: The aws-cli is installed when this parameter is set to true. Set to false to skip installation
     type: boolean
     default: true
+  image-tag:
+    description: >
+      The tag for the cimg/aws image. It defaults to 2023.03. For more information, please visit the image registry at
+      https://circleci.com/developer/images/image/cimg/aws
+    type: string
+    default: "2023.03"
 docker:
-  - image: cimg/aws:2023.03
+  - image: cimg/aws:<< parameters.image-tag >>
 steps:
   - check-health:
       aws-access-key-id: << parameters.aws-access-key-id >>

--- a/src/jobs/check-health.yml
+++ b/src/jobs/check-health.yml
@@ -16,40 +16,10 @@ parameters:
     description: >
       The max number of attempts to recheck for issues in the specified AWS region. Each attempt takes
       10 seconds. By default, 6 attempts will be made for a total of 1 minute.
-  aws-access-key-id:
-    type: env_var_name
-    description: aws access key id override
-    default: AWS_ACCESS_KEY_ID
-  aws-secret-access-key:
-    type: env_var_name
-    description: aws secret access key override
-    default: AWS_SECRET_ACCESS_KEY
-  aws-region:
-    type: env_var_name
-    description: aws region override
-    default: AWS_REGION
   profile-name:
     description: AWS profile name to be configured.
     type: string
-    default: ''
-  role-arn:
-    description: |
-      The Amazon Resource Name (ARN) of the role that the caller is assuming.
-      Role ARN must be configured for web identity.
-    type: string
-    default: ""
-  role-session-name:
-    description: An identifier for the assumed role session. Environment variables will be evaluated.
-    type: string
-    default: ${CIRCLE_JOB}
-  session-duration:
-    description: The duration of the session in seconds
-    type: string
-    default: "3600"
-  install-aws-cli:
-    description: The aws-cli is installed when this parameter is set to true. Set to false to skip installation
-    type: boolean
-    default: true
+    default: "default"
   image-tag:
     description: >
       The tag for the cimg/aws image. It defaults to 2023.03. For more information, please visit the image registry at
@@ -60,14 +30,7 @@ docker:
   - image: cimg/aws:<< parameters.image-tag >>
 steps:
   - check-health:
-      aws-access-key-id: << parameters.aws-access-key-id >>
-      aws-secret-access-key: << parameters.aws-secret-access-key >>
-      aws-region: << parameters.aws-region >>
       profile-name: << parameters.profile-name >>
       aws-region-to-check: << parameters.aws-region-to-check >>
       max-poll-attempts: << parameters.max-poll-attempts >>
-      install-aws-cli: << parameters.install-aws-cli >>
-      role-arn: << parameters.role-arn >>
-      role-session-name: << parameters.role-session-name >>
-      session-duration: << parameters.session-duration >>
 

--- a/src/scripts/check-health.sh
+++ b/src/scripts/check-health.sh
@@ -24,7 +24,7 @@ i=1
 while [ "$i" -le "$PARAM_AWS_HEALTH_MAX_POLL_ATTEMPTS" ]
 do
     echo "Poll Attempt #$i"
-    AWS_EVENTS=$(aws health describe-events --filter "${FILTER}" | jq .events)
+    AWS_EVENTS=$(aws health describe-events --filter "${FILTER}" --profile "${PARAM_AWS_HEALTH_PROFILE}" | jq .events)
     if [ "${AWS_EVENTS}" = "[]" ]; then
         echo "No issues found in ${PARAM_AWS_HEALTH_REGION_TO_CHECK} region";
         exit 0;


### PR DESCRIPTION
This `PR` removed the `executor` parameter from the `check-health` job and add the `aws` image as the executor. 

It also adds the `CODEOWNERS` file to the `.circleci` directory.