### PR TITLE
major:!  v2.0

### DIFF
--- a/src/commands/check_health.yml
+++ b/src/commands/check_health.yml
@@ -26,7 +26,7 @@ steps:
   - run:
       name: Checking Health of AWS << parameters.aws_region_to_check >>
       environment:
-        ORB_EVAL_REGION_TO_CHECK: << parameters.aws_region_to_check >>
-        ORB_VAL_MAX_POLL_ATTEMPTS: << parameters.max_poll_attempts >>
-        ORB_EVAL_PROFILE: << parameters.profile_name >>
+        ORB_STR_REGION_TO_CHECK: << parameters.aws_region_to_check >>
+        ORB_INT_MAX_POLL_ATTEMPTS: << parameters.max_poll_attempts >>
+        ORB_STR_PROFILE: << parameters.profile_name >>
       command: << include(scripts/check_health.sh) >>

--- a/src/examples/check_health_command.yml
+++ b/src/examples/check_health_command.yml
@@ -7,8 +7,8 @@ usage:
   version: 2.1
   orbs:
     aws-health: circleci/aws-health@1.0
-    aws-cli: circleci/aws-cli@3.1
-    aws-ecs: circleci/aws-ecs@3.2
+    aws-cli: circleci/aws-cli@4.0
+    aws-ecs: circleci/aws-ecs@4.0
   job:
     check_health_and_deploy:
       docker:

--- a/src/examples/check_health_job.yml
+++ b/src/examples/check_health_job.yml
@@ -7,8 +7,8 @@ usage:
   version: 2.1
   orbs:
     aws-health: circleci/aws-health@1.0
-    aws-cli: circleci/aws-cli@3.1
-    aws-ecs: circleci/aws-ecs@3.2
+    aws-cli: circleci/aws-cli@4.0
+    aws-ecs: circleci/aws-ecs@4.0
   workflows:
     check_health_and_deploy:
       jobs:

--- a/src/examples/check_health_job_with_oidc.yml
+++ b/src/examples/check_health_job_with_oidc.yml
@@ -5,7 +5,7 @@ usage:
   orbs:
     aws-health: circleci/aws-health@1.0
     # Importing aws-cli orb is required for OIDC authentication
-    aws-cli: circleci/aws-cli@3.1
+    aws-cli: circleci/aws-cli@4.0
 
   workflows:
     check_health_and_deploy:

--- a/src/examples/check_health_job_with_static_keys.yml
+++ b/src/examples/check_health_job_with_static_keys.yml
@@ -7,7 +7,7 @@ usage:
   orbs:
     aws-health: circleci/aws-health@1.0
     # Importing aws-cli orb is required for authentication
-    aws-cli: circleci/aws-cli@3.1
+    aws-cli: circleci/aws-cli@4.0
 
   workflows:
     check_health_and_deploy:

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -1,0 +1,17 @@
+description: |
+  An AWS Docker image built to run on CircleCI that contains the AWS CLI and related tools.
+parameters:
+  tag:
+    description: >
+      Select any of the available tags here: https://circleci.com/developer/images/image/cimg/aws.
+    type: string
+    default: "2023.03"
+  resource_class:
+    description: Configure the executor resource class
+    type: enum
+    enum: ["small", "medium", "medium+", "large", "xlarge", "2xlarge", "2xlarge+"]
+    default: "medium"
+
+docker:
+  - image: cimg/aws:<<parameters.tag>>
+resource_class: <<parameters.resource_class>>

--- a/src/jobs/check_health.yml
+++ b/src/jobs/check_health.yml
@@ -25,14 +25,11 @@ parameters:
       The authentication method used to access your AWS account. Import the aws-cli orb in your config and
       provide the aws-cli/setup command to authenticate with your preferred method. View examples for more information.
     type: steps
-  image_tag:
-    description: >
-      The tag for the cimg/aws image. It defaults to 2023.03. For more information, please visit the image registry at
-      https://circleci.com/developer/images/image/cimg/aws
-    type: string
-    default: "2023.03"
-docker:
-  - image: cimg/aws:<< parameters.image_tag >>
+  executor:
+    description: The executor to use for this job. By default, this will use the "default" executor provided by this orb.
+    type: executor
+    default: default
+executor: << parameters.executor >>
 steps:
   - steps: << parameters.auth >>
   - check_health:

--- a/src/scripts/check_health.sh
+++ b/src/scripts/check_health.sh
@@ -15,23 +15,23 @@ if grep "Alpine" /etc/issue > /dev/null 2>&1; then
     fi
 fi
 
-ORB_EVAL_REGION_TO_CHECK="$(circleci env subst "${ORB_EVAL_REGION_TO_CHECK}")"
-ORB_EVAL_PROFILE="$(circleci env subst "${ORB_EVAL_PROFILE}")"
+ORB_STR_REGION_TO_CHECK="$(circleci env subst "${ORB_STR_REGION_TO_CHECK}")"
+ORB_STR_PROFILE="$(circleci env subst "${ORB_STR_PROFILE}")"
 
 
-FILTER="{\"regions\": ["\"${ORB_EVAL_REGION_TO_CHECK}\""],\"eventTypeCategories\": [\"issue\"], \"eventStatusCodes\": [\"open\",\"upcoming\"]}"
-echo "Checking Health for ${ORB_EVAL_REGION_TO_CHECK} region"
+FILTER="{\"regions\": ["\"${ORB_STR_REGION_TO_CHECK}\""],\"eventTypeCategories\": [\"issue\"], \"eventStatusCodes\": [\"open\",\"upcoming\"]}"
+echo "Checking Health for ${ORB_STR_REGION_TO_CHECK} region"
 
 i=1
-while [ "$i" -le "$ORB_VAL_MAX_POLL_ATTEMPTS" ]
+while [ "$i" -le "$ORB_INT_MAX_POLL_ATTEMPTS" ]
 do
     echo "Poll Attempt #$i"
-    AWS_EVENTS=$(aws health describe-events --filter "${FILTER}" --profile "${ORB_EVAL_PROFILE}" | jq .events)
+    AWS_EVENTS=$(aws health describe-events --filter "${FILTER}" --profile "${ORB_STR_PROFILE}" | jq .events)
     if [ "${AWS_EVENTS}" = "[]" ]; then
-        echo "No issues found in ${ORB_EVAL_REGION_TO_CHECK} region";
+        echo "No issues found in ${ORB_STR_REGION_TO_CHECK} region";
         exit 0;
-    elif [ "$i" -eq "$ORB_VAL_MAX_POLL_ATTEMPTS" ]; then
-        echo "Max attempts reached. Issues found in ${ORB_EVAL_REGION_TO_CHECK} region:"
+    elif [ "$i" -eq "$ORB_INT_MAX_POLL_ATTEMPTS" ]; then
+        echo "Max attempts reached. Issues found in ${ORB_STR_REGION_TO_CHECK} region:"
         echo "${AWS_EVENTS}"
         exit 1;
     else


### PR DESCRIPTION
This `PR` contains the final changes required for the `v2.0` release of the `AWS Health` orb: 

1. Updates variable names to comply with Orb Standardization Guide
2. Replaces job image with a `default` executor using the `cimg/aws` convenience image. 
